### PR TITLE
Expose outside and root diameter to freecad

### DIFF
--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -122,6 +122,10 @@ class InvoluteGear(BaseGear):
                         "gear", "gear_parameter", "test")
         obj.addProperty("App::PropertyLength", "dw",
                         "computed", "pitch diameter", 1)
+        obj.addProperty("App::PropertyLength", "da",
+                        "computed", "outside diameter", 1)
+        obj.addProperty("App::PropertyLength", "df",
+                        "computed", "root diameter", 1)
         obj.addProperty("App::PropertyLength", "transverse_pitch",
                         "computed", "transverse_pitch", 1)
         obj.gear = self.involute_tooth
@@ -188,6 +192,8 @@ class InvoluteGear(BaseGear):
 
         # computed properties
         fp.dw = "{}mm".format(fp.gear.dw)
+        fp.da = "{}mm".format(fp.gear.da)
+        fp.df = "{}mm".format(fp.gear.df)
         fp.transverse_pitch = "{}mm".format(fp.gear.pitch)
 
     def __getstate__(self):

--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -122,12 +122,9 @@ class InvoluteGear(BaseGear):
                         "gear", "gear_parameter", "test")
         obj.addProperty("App::PropertyLength", "dw",
                         "computed", "pitch diameter", 1)
-        obj.addProperty("App::PropertyLength", "da",
-                        "computed", "outside diameter", 1)
-        obj.addProperty("App::PropertyLength", "df",
-                        "computed", "root diameter", 1)
         obj.addProperty("App::PropertyLength", "transverse_pitch",
                         "computed", "transverse_pitch", 1)
+        self.add_limiting_diameter_properties(obj)
         obj.gear = self.involute_tooth
         obj.simple = False
         obj.undercut = False
@@ -146,6 +143,12 @@ class InvoluteGear(BaseGear):
         obj.properties_from_tool = False
         self.obj = obj
         obj.Proxy = self
+
+    def add_limiting_diameter_properties(self, obj):
+        obj.addProperty("App::PropertyLength", "da",
+                        "computed", "outside diameter", 1)
+        obj.addProperty("App::PropertyLength", "df",
+                        "computed", "root diameter", 1)
 
     def execute(self, fp):
         fp.gear.double_helix = fp.double_helix
@@ -192,9 +195,12 @@ class InvoluteGear(BaseGear):
 
         # computed properties
         fp.dw = "{}mm".format(fp.gear.dw)
+        fp.transverse_pitch = "{}mm".format(fp.gear.pitch)
+        # checksbackwardcompatibility:
+        if not "da" in fp.PropertiesList:
+            self.add_limiting_diameter_properties(fp)
         fp.da = "{}mm".format(fp.gear.da)
         fp.df = "{}mm".format(fp.gear.df)
-        fp.transverse_pitch = "{}mm".format(fp.gear.pitch)
 
     def __getstate__(self):
         return None


### PR DESCRIPTION
The values are already calculated by pygear and this change make them
available as properties in FreeCAD.
The naming should be in line with the rest of fcgear's nomenclature,
derived from https://qtcgears.com/tools/catalogs/PDF_Q420/Tech.pdf