### PR TITLE
Improve support for gears in PartDesign bodies

### DIFF
--- a/freecad/gears/commands.py
+++ b/freecad/gears/commands.py
@@ -63,7 +63,7 @@ class BaseCommand(object):
             cls.GEAR_FUNCTION(obj)
 
             if body:
-                body.Group += [obj]
+                body.addObject(obj)
             elif part:
                 part.Group += [obj]
         else:

--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -422,6 +422,8 @@ class CrownGear(BaseGear):
         inner_circle.reverse()
         face = Part.Face([outer_circle, inner_circle])
         solid = face.extrude(App.Vector([0., 0., -fp.thickness.Value]))
+        if fp.preview_mode:
+            return solid
 
         # cutting obj
         alpha_w = np.deg2rad(fp.pressure_angle.Value)
@@ -443,17 +445,11 @@ class CrownGear(BaseGear):
         loft = makeLoft(polies, True)
         rot = App.Matrix()
         rot.rotateZ(2 * np.pi / t)
-        if fp.preview_mode:
-            cut_shapes = [solid]
-            for _ in range(t):
-                loft = loft.transformGeometry(rot)
-                cut_shapes.append(loft)
-            return Part.Compound(cut_shapes)
-        else:
-            for i in range(t):
-                loft = loft.transformGeometry(rot)
-                solid = solid.cut(loft)
-            return solid
+        cut_shapes = []
+        for _ in range(t):
+            loft = loft.transformGeometry(rot)
+            cut_shapes.append(loft)
+        return solid.cut(cut_shapes)
 
     def __getstate__(self):
         pass


### PR DESCRIPTION
With this patch gears now play nicely with PartDesign's concept of stacking features onto each other, i.e. that the result of a feature is the fusion of all previous ones: In a PD Body, a gear is now an "additive feature".

Special Thanks goes to DeepSOIC for his [tutorial in the forum](https://forum.freecadweb.org/viewtopic.php?f=22&t=21097#p163340) as well as this Part-o-Matic which showed me [how this works in real live](https://github.com/DeepSOIC/Part-o-magic/blob/master/PartOMagic/Features/PartDesign/PDShapeFeature.py)

Tasks:
- [x] Ensure removing of gears closes the gap in the feature sequence
- [x] Cleanup and roll out to all other types of gears
- [x] Handle the preview-mode of the crown-gear, which returns a compound, not a solid, as shape
- [x] Take a look at the `height=0` special case, where only the profile is returned, not a solid
  - This is not supported in all conditions, see [my comment below](https://github.com/looooo/freecad.gears/pull/74#issuecomment-881970355)
- [ ] ~Maybe even "subtractive gears", let's see where this goes...~ This needs more thinking, so let's keep this for a separate PR:
  - Straight forward implementation is not that hard, but may result in bad usability: Pad and Pocket work in opposite direction, so this should be kept for gears, too. But just mirroring the gear would have unexpected side effects on helical gears (shifting the origin could be an option).
  - Using a property to switch between pad/pocket of a profile seems also odd (but would be in-line with the "hight=zero turns solid into profile"-thing).
  - The main use case are internal gears, which right now can only be "faked" by playing with head/clearance. Also not straight forward for the user...