### PR TITLE
Backport head parameter for cycloid gear

### DIFF
--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -478,6 +478,7 @@ class CycloidGear(BaseGear):
             "App::PropertyBool", "double_helix", "gear_parameter", "double helix")
         obj.addProperty(
             "App::PropertyFloat", "clearance", "gear_parameter", "clearance")
+        self._add_head_property(obj)
         obj.addProperty("App::PropertyInteger", "numpoints",
                         "precision", "number of points for spline")
         obj.addProperty("App::PropertyAngle", "beta", "gear_parameter", "beta")
@@ -498,12 +499,21 @@ class CycloidGear(BaseGear):
         obj.double_helix = False
         obj.Proxy = self
 
+    def _add_head_property(self, obj):
+        obj.addProperty("App::PropertyFloat", "head", "gear_parameter",
+            "head * modul = additional length of addendum")
+        obj.head = 0.0
+
     def generate_gear_shape(self, fp):
         fp.gear.m = fp.module.Value
         fp.gear.z = fp.teeth
         fp.gear.z1 = fp.inner_diameter.Value
         fp.gear.z2 = fp.outer_diameter.Value
         fp.gear.clearance = fp.clearance
+        # check backward compatibility:
+        if not "head" in fp.PropertiesList:
+            self._add_head_property(fp)
+        fp.gear.head = fp.head
         fp.gear.backlash = fp.backlash.Value
         fp.gear._update()
 

--- a/pygears/cycloid_tooth.py
+++ b/pygears/cycloid_tooth.py
@@ -25,10 +25,11 @@ from ._functions import rotation, reflection
 
 
 class CycloidTooth():
-    def __init__(self, z1=5, z2=5, z=14, m=5, clearance=0.12, backlash=0.00):
+    def __init__(self, z1=5, z2=5, z=14, m=5, clearance=0.12, backlash=0.00, head=0.0):
         self.m = m
         self.z = z
         self.clearance = clearance
+        self.head = head
         self.backlash = backlash
         self.z1 = z1
         self.z2 = z2
@@ -39,7 +40,7 @@ class CycloidTooth():
         self.d2 = self.z2 * self.m
         self.phi = self.m * pi
         self.d = self.z * self.m
-        self.da = self.d + 2*self.m
+        self.da = self.d + 2*self.m + self.head * self.m
         self.di = self.d - 2*self.m - self.clearance * self.m
         self.phipart = 2 * pi / self.z
 
@@ -103,5 +104,5 @@ class CycloidTooth():
 
     def _update(self):
         self.__init__(m=self.m, z=self.z, z1=self.z1, z2=self.z2,
-                      clearance=self.clearance, backlash=self.backlash)
+                      clearance=self.clearance, backlash=self.backlash, head=self.head)
 


### PR DESCRIPTION
This is a backport of commit 9ddd493b from develop, with two changes:
- unrelated changes have not been back ported
- backwards compatibility was added

Note that the actual usage of the head value in pygear is wrong, though: As it is added to the diameter (not the radius) it should have been added twice. However, as the clearance suffers from the same bug, I chose to stay consistent. A fix should address both, head and clearance, but this is out of scope here. With #93 I've submitted a fix for the develop branch, but for master such a fix is breaking (existing models would see a larger clearance, up to the point where a recompute ca fail).