### PR TITLE
Use expression as `inner_diameter` for cycloid gear

### DIFF
--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -606,7 +606,7 @@ class CycloidGearRack(BaseGear):
         obj.teeth = 15
         obj.module = '1. mm'
         obj.inner_diameter = 7.5
-        obj.outer_diameter= 7.5
+        obj.outer_diameter = 7.5
         obj.height = '5. mm'
         obj.thickness = '5 mm'
         obj.beta = '0. deg'
@@ -863,8 +863,8 @@ class CycloidGear(BaseGear):
         obj.gear = self.cycloid_tooth
         obj.teeth = 15
         obj.module = '1. mm'
-        obj.inner_diameter = 7.5
-        obj.outer_diameter = 7.5
+        obj.setExpression('inner_diameter', 'teeth / 2') # teeth/2 makes the hypocycloid a straight line to the center
+        obj.outer_diameter = 7.5 # we don't know the mating gear, so we just set the default to mesh with our default
         obj.beta = '0. deg'
         obj.height = '5. mm'
         obj.clearance = 0.25


### PR DESCRIPTION
The cycloid gear is created with a default number of teeth of 15 and an `inner_diameter` of 7.5. That is half the number of teeth and results in an hypocycloid going orthogonal from the pitch circle right to the center.
This change now replaces the hard coded value "7.5" with the expression "teeth / 2" so that this straight hypocycloid is kept, even if the number of teeth is adapted. This allows easy reduction of the number of teeth (down to two, in fact) without the recomputation to fail.