### PR TITLE
Fixed issue loading old document without traverse_module in gear XML

### DIFF
--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -189,7 +189,7 @@ class InvoluteGear(BaseGear):
                         "computed", "outside diameter", 1)
         obj.addProperty("App::PropertyLength", "df",
                         "computed", "root diameter", 1)
-        obj.addProperty("App::PropertyLength", "traverse_module", "computed", "traverse module of the generated gear", 1)
+        self.add_traverse_module_property(obj)
         obj.addProperty("App::PropertyLength", "dw", "computed", "The pitch diameter.", 1)
         obj.addProperty("App::PropertyAngle", "angular_backlash", "computed",
             "The angle by which this gear can turn without moving the mating gear.")
@@ -211,8 +211,14 @@ class InvoluteGear(BaseGear):
         obj.addProperty("App::PropertyBool", "simple", "accuracy", "simple")
         obj.addProperty("App::PropertyInteger", "numpoints",
                         "accuracy", "number of points for spline")
+        
+    def add_traverse_module_property(self, obj):
+        obj.addProperty("App::PropertyLength", "traverse_module", "computed", "traverse module of the generated gear", 1)
 
     def compute_traverse_properties(self, obj):
+        # traverse_module added recently, if old freecad doc is loaded without it, it will not exist when generate_gear_shape() is called
+        if not hasattr(obj, 'traverse_module'):
+            self.add_traverse_module_property(obj)
         if obj.properties_from_tool:
             obj.traverse_module = obj.module / np.cos(obj.gear.beta)
         else:


### PR DESCRIPTION
I had an issue with backward compatibility with loading some old documents which had gears generated by this plugin. At that time, fcgears did not add the `traverse_module` property to the Involute gears objects, so this property was not written out to the associated object XML.

When these old documents are loaded, these object XMLs are deserialized and loaded, and the default InvoluteGear constructor appears to be bypassed by the time `generate_gear_shape()` is called.

Because of this, the plugin would crash in `compute_traverse_properties()`, reporting `FeaturePython has no attribute 'traverse_module'...`

This PR fixes this by checking if the object has this attribute, and if it doesn't, it adds it within `compute_traverse_properties` with default values.

Any new properties being added in the future should probably have similar logic added to ensure this kind of thing doesn't occur.