### PR TITLE
Remove LGTM badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## A Gear module for FreeCAD
-[![Liberapay](http://img.shields.io/liberapay/patrons/looooo.svg?logo=liberapay)](https://liberapay.com/looooo/donate) [![Total alerts](https://img.shields.io/lgtm/alerts/g/looooo/freecad.gears.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/looooo/freecad.gears/alerts/) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/looooo/freecad.gears.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/looooo/freecad.gears/context:python)  
+[![Liberapay](http://img.shields.io/liberapay/patrons/looooo.svg?logo=liberapay)](https://liberapay.com/looooo/donate) 
 
 ## Requirements
 FreeCAD > v0.16  


### PR DESCRIPTION
LGTM was folded into Gitub (https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)