### PR TITLE
Update features.py to support HTD Timing Gear Profiles

### DIFF
--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -1302,13 +1302,15 @@ class WormGear(BaseGear):
 
 
 class TimingGear(BaseGear):
-
     """FreeCAD gear rack"""
-    data = {"gt2":  {'pitch': 2.0, 'u': 0.254,  'h': 0.75,
+    data = {
+            "gt2":  {
+                    'pitch': 2.0, 'u': 0.254,  'h': 0.75,
                     'H': 1.38,    'r0': 0.555, 'r1': 1.0,
                     'rs': 0.15,   'offset': 0.40
                     },
-            "gt3":  {'pitch': 3.0, 'u': 0.381, 'h': 1.14,
+            "gt3":  {
+                    'pitch': 3.0, 'u': 0.381, 'h': 1.14,
                     'H': 2.40, 'r0': 0.85, 'r1': 1.52,
                     'rs': 0.25, 'offset': 0.61
                     },
@@ -1317,29 +1319,42 @@ class TimingGear(BaseGear):
                     'H': 3.81,  'r0': 1.44,  'r1': 2.57,
                     'rs': 0.416,  'offset': 1.03
                     },
-            "htd8":  {
+            "gt8":  {
                     'pitch': 8.0,  'u': 0.9144,  'h': 3.088,
                     'H': 6.096,  'r0': 2.304,  'r1': 4.112,
                     'rs': 0.6656,  'offset': 1.648
-                    } 
+                    },
+            "htd3": {
+                    'pitch': 3.0, 'u': 0.381, 'h': 1.21,
+                    'H': 2.40, 'r0': 0.89, 'r1': 0.89,
+                    'rs': 0.26, 'offset': 0.0
+                    },
+            "htd5": {
+                    'pitch': 5.0, 'u': 0.5715, 'h': 2.06,
+                    'H': 3.80, 'r0': 1.49, 'r1': 1.49,
+                    'rs': 0.43, 'offset': 0.0
+                    },
+            "htd8": {
+                    'pitch': 8.0, 'u': 0.686, 'h': 3.45,
+                    'H': 6.00, 'r0': 2.46, 'r1': 2.46,
+                    'rs': 0.70, 'offset': 0.0
+                    }
             }
 
     def __init__(self, obj):
         super(TimingGear, self).__init__(obj)
-        obj.addProperty("App::PropertyInteger",
-                        "teeth", "base", "number of teeth")
+        obj.addProperty("App::PropertyInteger", "teeth", "base", "number of teeth")
         obj.addProperty( "App::PropertyEnumeration", "type", "base", "type of timing-gear")
         obj.addProperty( "App::PropertyLength", "height", "base", "height")
-        obj.addProperty( "App::PropertyLength", "pitch", "computed", "pitch off gear", 1)
+        obj.addProperty( "App::PropertyLength", "pitch", "computed", "pitch of gear", 1)
         obj.addProperty( "App::PropertyLength", "h", "computed", "radial height of teeth", 1)
-        obj.addProperty( "App::PropertyLength", "u", "computed", "radial difference between pitch \
-            diameter and head of gear", 1)
+        obj.addProperty( "App::PropertyLength", "u", "computed", "radial difference between pitch diameter and head of gear", 1)
         obj.addProperty( "App::PropertyLength", "r0", "computed", "radius of first arc", 1)
         obj.addProperty( "App::PropertyLength", "r1", "computed", "radius of second arc", 1)
         obj.addProperty( "App::PropertyLength", "rs", "computed", "radius of third arc", 1)
         obj.addProperty( "App::PropertyLength", "offset", "computed", "x-offset of second arc-midpoint", 1)
         obj.teeth = 15
-        obj.type = ['gt2', 'gt3', 'gt5', 'htd8']
+        obj.type = ['gt2', 'gt3', 'gt5', 'gt8', 'htd3', 'htd5', 'htd8']
         obj.height = '5. mm'
 
         self.obj = obj
@@ -1360,60 +1375,77 @@ class TimingGear(BaseGear):
         r_34 = fp.rs = gt_data["rs"]
         offset = fp.offset = gt_data["offset"]
 
-        phi_12 = np.arctan(np.sqrt(1. / (((r_12 - r_23) / offset) ** 2 - 1)))
-        rp = pitch * fp.teeth / np.pi / 2.
-        r4 = r5 = rp - u
+        arcs = []
+        if offset == 0.:
+          phi5 = np.pi / fp.teeth
+          ref = reflection(-phi5 - np.pi / 2.)
+          rp = pitch * fp.teeth / np.pi / 2. - u
+          
+          m_34 = np.array([-(r_12 + r_34), rp - h + r_12])
+          x2 = np.array([-r_12, m_34[1]])
+          x4 = np.array([m_34[0], m_34[1] + r_34])
+          x6 = ref(x4)
 
-        m_12 = np.array([0., r5 - h + r_12])
-        m_23 = np.array([offset, offset / np.tan(phi_12) + m_12[1]])
-        m_23y = m_23[1]
+          mir = np.array([-1., 1.])
+          xn2 = mir * x2
+          xn4 = mir * x4
+          mn_34 = mir * m_34
 
-        # solving for phi4:
-        # sympy.solve(
-        # ((r5 - r_34) * sin(phi4) + offset) ** 2 + \
-        # ((r5 - r_34) * cos(phi4) - m_23y) ** 2 - \
-        # ((r_34 + r_23) ** 2), phi4)
+          arcs.append(part_arc_from_points_and_center(xn4, xn2, mn_34).toShape())
+          arcs.append(Part.Arc(App.Vector(*xn2, 0.), App.Vector(0, rp - h, 0.), App.Vector(*x2, 0.)).toShape())
+          arcs.append(part_arc_from_points_and_center(x2, x4, m_34).toShape())
+          arcs.append(part_arc_from_points_and_center(x4, x6, np.array([0. ,0.])).toShape())
 
-        
-        phi4 = 2*np.arctan((-2*offset*r5 + 2*offset*r_34 + np.sqrt(-m_23y**4 - 2*m_23y**2*offset**2 + \
-        2*m_23y**2*r5**2 - 4*m_23y**2*r5*r_34 + 2*m_23y**2*r_23**2 + \
-        4*m_23y**2*r_23*r_34 + 4*m_23y**2*r_34**2 - offset**4 + 2*offset**2*r5**2 - \
-        4*offset**2*r5*r_34 + 2*offset**2*r_23**2 + 4*offset**2*r_23*r_34 + 4*offset**2*r_34**2 - \
-        r5**4 + 4*r5**3*r_34 + 2*r5**2*r_23**2 + 4*r5**2*r_23*r_34 - \
-        4*r5**2*r_34**2 - 4*r5*r_23**2*r_34 - 8*r5*r_23*r_34**2 - r_23**4 - \
-        4*r_23**3*r_34 - 4*r_23**2*r_34**2))/(m_23y**2 + 2*m_23y*r5 - \
-        2*m_23y*r_34 + offset**2 + r5**2 - 2*r5*r_34 - r_23**2 - 2*r_23*r_34))
+        else:
+          phi_12 = np.arctan(np.sqrt(1. / (((r_12 - r_23) / offset) ** 2 - 1)))
+          rp = pitch * fp.teeth / np.pi / 2.
+          r4 = r5 = rp - u
 
-        phi5 = np.pi / fp.teeth
+          m_12 = np.array([0., r5 - h + r_12])
+          m_23 = np.array([offset, offset / np.tan(phi_12) + m_12[1]])
+          m_23y = m_23[1]
 
+          # solving for phi4:
+          # sympy.solve(
+          # ((r5 - r_34) * sin(phi4) + offset) ** 2 + \
+          # ((r5 - r_34) * cos(phi4) - m_23y) ** 2 - \
+          # ((r_34 + r_23) ** 2), phi4)
 
-        m_34 = (r5 - r_34) * np.array([-np.sin(phi4), np.cos(phi4)])
+          phi4 = 2*np.arctan((-2*offset*r5 + 2*offset*r_34 + np.sqrt(-m_23y**4 - 2*m_23y**2*offset**2 + \
+          2*m_23y**2*r5**2 - 4*m_23y**2*r5*r_34 + 2*m_23y**2*r_23**2 + \
+          4*m_23y**2*r_23*r_34 + 4*m_23y**2*r_34**2 - offset**4 + 2*offset**2*r5**2 - \
+          4*offset**2*r5*r_34 + 2*offset**2*r_23**2 + 4*offset**2*r_23*r_34 + 4*offset**2*r_34**2 - \
+          r5**4 + 4*r5**3*r_34 + 2*r5**2*r_23**2 + 4*r5**2*r_23*r_34 - \
+          4*r5**2*r_34**2 - 4*r5*r_23**2*r_34 - 8*r5*r_23*r_34**2 - r_23**4 - \
+          4*r_23**3*r_34 - 4*r_23**2*r_34**2))/(m_23y**2 + 2*m_23y*r5 - \
+          2*m_23y*r_34 + offset**2 + r5**2 - 2*r5*r_34 - r_23**2 - 2*r_23*r_34))
 
+          phi5 = np.pi / fp.teeth
 
-        x2 = np.array([-r_12 * np.sin(phi_12), m_12[1] - r_12 * np.cos(phi_12)])
-        x3 = m_34 + r_34 / (r_34 + r_23) * (m_23 - m_34)
-        x4 = r4 * np.array([-np.sin(phi4), np.cos(phi4)])
+          m_34 = (r5 - r_34) * np.array([-np.sin(phi4), np.cos(phi4)])
 
+          x2 = np.array([-r_12 * np.sin(phi_12), m_12[1] - r_12 * np.cos(phi_12)])
+          x3 = m_34 + r_34 / (r_34 + r_23) * (m_23 - m_34)
+          x4 = r4 * np.array([-np.sin(phi4), np.cos(phi4)])
 
-        ref = reflection(-phi5 - np.pi / 2)
-        x6 = ref(x4)
-        mir = np.array([-1., 1.])
-        xn2 = mir * x2
-        xn3 = mir * x3
-        xn4 = mir * x4
+          ref = reflection(-phi5 - np.pi / 2)
+          x6 = ref(x4)
+          mir = np.array([-1., 1.])
+          xn2 = mir * x2
+          xn3 = mir * x3
+          xn4 = mir * x4
 
-        mn_34 = mir * m_34
-        mn_23 = mir * m_23
+          mn_34 = mir * m_34
+          mn_23 = mir * m_23
 
+          arcs.append(part_arc_from_points_and_center(xn4, xn3, mn_34).toShape())
+          arcs.append(part_arc_from_points_and_center(xn3, xn2, mn_23).toShape())
+          arcs.append(part_arc_from_points_and_center(xn2, x2, m_12).toShape())
+          arcs.append(part_arc_from_points_and_center(x2, x3, m_23).toShape())
+          arcs.append(part_arc_from_points_and_center(x3, x4, m_34).toShape())
+          arcs.append(part_arc_from_points_and_center(x4, x6, np.array([0. ,0.])).toShape())
 
-        arc_1 = part_arc_from_points_and_center(xn4, xn3, mn_34).toShape()
-        arc_2 = part_arc_from_points_and_center(xn3, xn2, mn_23).toShape()
-        arc_3 = part_arc_from_points_and_center(xn2, x2, m_12).toShape()
-        arc_4 = part_arc_from_points_and_center(x2, x3, m_23).toShape()
-        arc_5 = part_arc_from_points_and_center(x3, x4, m_34).toShape()
-        arc_6 = part_arc_from_points_and_center(x4, x6, np.array([0. ,0.])).toShape()
-
-        wire = Part.Wire([arc_1, arc_2, arc_3, arc_4, arc_5, arc_6])
+        wire = Part.Wire(arcs)
         wires = [wire]
         rot = App.Matrix()
         rot.rotateZ(np.pi * 2 / fp.teeth)


### PR DESCRIPTION
I was frustrated that the GT3 gear generation in Freecad, while looking incredibly similar, did not work with the HTD gears and belts I require. The GT3 profile was slipping when trying to use a HTD3 belt. This led me down a Google rabbit hole with an utter lack of documentation. I eventually found a reasonably detailed HTD specification from a manufacturer in Singapore.

Reference Documentation: http://misbelt.com/wp-content/uploads/2018/01/htd.pdf

Using this information, I then added the 3M, 5M, 8M HTD Timing Gear Profiles.
Additionally I corrected the GT8 Profile naming from "htd8" to "gt8".

Sample Profile Difference:
![GT3 HTD3 Gear Profile Difference](https://github.com/looooo/freecad.gears/assets/6614673/47764ff7-fbee-4a57-bc5e-b781f3178890)

NOTE: I've noticed that the GT# gear diameters are different from the HTD# diameters for different number of teeth, but I have not had the need/opportunity to look into why the GT# profile configurations have a difference in diameters. Depending on time/availability I could look into additional timing gear profiles, but that won't be for a while.