### PR TITLE
Avoid self-crossing of involute teeth

### DIFF
--- a/pygears/involute_tooth.py
+++ b/pygears/involute_tooth.py
@@ -94,6 +94,13 @@ class InvoluteTooth():
         y = array(list(map(fy, pts)))
         rot = rotation(self.involute_rot - self.angular_backlash / 2)
         xy = rot(transpose(array([x, y])))
+        # The points should not leave the angular range of one side of the tooth, either by overshooting
+        # the tip (and so having to double back to create the other side) or by overlapping with the
+        # adjacent tooth at the base.
+        no_self_cross_at_tip_filter = xy[:, 1] <= 0
+        xy = xy[no_self_cross_at_tip_filter]
+        no_self_cross_at_base_filter = -arctan(xy[:,1] / xy[:, 0]) < self.phipart / 2
+        xy = xy[no_self_cross_at_base_filter]
         return(xy)
 
     def points(self, num=10):


### PR DESCRIPTION
At extreme pressure angles (e.g. 45 degrees), the line defining the gear surface would have self-crossings at tooth tips and bases before this fix. The curve defined by involute_points was leaving the angular range (0 to self.phipart / 2) allowed for the half of the tooth.

This screenshot demonstrates the problem. This is the default involute gear that gets created from the workbench, except with the pressure angle changes to 45 degrees and numpoints turned up to 10.

![image](https://github.com/looooo/freecad.gears/assets/890971/cac8da74-5093-41fa-b432-119e27028299)
