### PR TITLE
[Gears] Remove use of deepcopy due to the change in FreeCAD core code

### DIFF
--- a/freecad/gears/connector.py
+++ b/freecad/gears/connector.py
@@ -17,7 +17,6 @@
 # ***************************************************************************
 
 import os
-import copy
 import numpy as np
 import FreeCAD
 from pygears import __version__

--- a/freecad/gears/features.py
+++ b/freecad/gears/features.py
@@ -18,7 +18,6 @@
 
 from __future__ import division
 import os
-import copy
 
 import numpy as np
 import math
@@ -620,7 +619,7 @@ class InvoluteGearRack(BaseGear):
         teeth = [tooth]
 
         for i in range(obj.teeth - 1):
-            tooth = copy.deepcopy(tooth)
+            tooth = tooth.copy()
             tooth.translate(App.Vector(0, np.pi * m, 0))
             teeth.append(tooth)
 
@@ -780,7 +779,7 @@ class CycloidGearRack(BaseGear):
         teeth = [tooth]
 
         for i in range(obj.teeth - 1):
-            tooth = copy.deepcopy(tooth)
+            tooth = tooth.copy()
             tooth.translate(App.Vector(0, np.pi * m, 0))
             teeth.append(tooth)
 

--- a/pygears/involute_tooth.py
+++ b/pygears/involute_tooth.py
@@ -180,7 +180,6 @@ class InvoluteRack(object):
             self.simplified = False
 
     def points(self, num=10):
-        import copy
         m, m_n, pitch, pressure_angle_t = self.compute_properties()
 
         a = (2 + self.head + self.clearance) * m_n * tan(pressure_angle_t)
@@ -198,7 +197,7 @@ class InvoluteRack(object):
                 tooth = trans(tooth).tolist()
             else:
                 tooth = trans(tooth).tolist()
-                teeth.append(copy.deepcopy(tooth))
+                teeth.append(tooth.copy())
                 if self.simplified and (i == 3):
                     teeth[-1].pop()
                     teeth[-1].pop()


### PR DESCRIPTION
 See https://github.com/FreeCAD/FreeCAD/issues/11514

Tested with :

```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.20.2.29697 (Git)
Build type: Release
Branch: releases/FreeCAD-0-20
Hash: 5fe2a07044a1523c79ca94b1b124c3a3571708d6
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.3.0
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.0.0
  * Curves 0.6.13
  * Help 1.0.3
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```

```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.21.2.33772 (Git)
Build type: Release
Branch: releases/FreeCAD-0-21
Hash: abf147e2112c1ded4918435d2540f02be8a1ffc0
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.0.0
  * Curves 0.6.13
  * Help 1.0.3
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```



```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.35195 (Git)
Build type: Release
Branch: main
Hash: ac4a8780521fef72569498426c66f67abab77e1d
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Silk 0.1.3
  * Defeaturing 1.2.0
  * CurvedShapes 1.0.4
  * freecad.gears 1.0.0
  * Curves 0.6.13
  * Help 1.0.3
  * fasteners 0.4.56
  * sheetmetal 0.3.0
```
