### PR TITLE
[Gears] Fix AddonManager not updating to...

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,11 +2,11 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>freecad.gears workbench</name>
   <description>A gear workbench for FreeCAD</description>
-  <version>1.0</version>
+  <version>1.1</version>
   <date>2022-02-07</date>
   <maintainer email="sppedflyer@gmail.com">looooo</maintainer>
   <license file="LICENSE">GPL 3</license>
-  <url type="repository" branch="develop">https://github.com/looooo/freecad.gears</url>
+  <url type="repository" branch="master">https://github.com/looooo/freecad.gears</url>
   <url type="bugtracker">https://github.com/looooo/freecad.gears/issues</url>
   <url type="documentation">https://wiki.freecad.org/FCGear_Workbench</url>
   <icon>freecad/gears/icons/gearworkbench.svg</icon>


### PR DESCRIPTION
 ...most recent master commit

Fixes https://github.com/looooo/freecad.gears/issues/135

@looooo I noticed this after your merged my fix earlier today that my Debian 12 Vm wasn't showing that an update was available.