### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>1.2</version>
   <date>2022-02-07</date>
   <maintainer email="sppedflyer@gmail.com">looooo</maintainer>
-  <license file="LICENSE">GPL 3</license>
+  <license file="LICENSE">GPL-3.0-or-later</license>
   <url type="repository" branch="master">https://github.com/looooo/freecad.gears</url>
   <url type="bugtracker">https://github.com/looooo/freecad.gears/issues</url>
   <url type="documentation">https://wiki.freecad.org/FCGear_Workbench</url>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `GPL-3.0-only`, in which case use that instead.
