### PR TITLE
Added `dumps`, `loads`, and other methods to serialize and de-serialize.

### DIFF
--- a/freecad/gears/basegear.py
+++ b/freecad/gears/basegear.py
@@ -76,12 +76,10 @@ class ViewProviderGear:
         return self.icon_fn
 
     def dumps(self):
-        self._check_attr()
-        return {"icon_fn": self.icon_fn}
+        return self.__getstate__()
 
     def loads(self, state):
-        if state and "icon_fn" in state:
-            self.icon_fn = state["icon_fn"]
+        self.__setstate__(state)
 
     def __getstate__(self):
         self._check_attr()
@@ -90,7 +88,6 @@ class ViewProviderGear:
     def __setstate__(self, state):
         if state and "icon_fn" in state:
             self.icon_fn = state["icon_fn"]
-
 
 class BaseGear:
     def __init__(self, obj):
@@ -159,19 +156,17 @@ class BaseGear:
         """
         raise NotImplementedError("generate_gear_shape not implemented")
 
-
-    def loads(self, state):
-        pass
+    def loads(self, state) -> None:
+        return self.__setstate__(state)
 
     def dumps(self):
-        pass
+        return self.__getstate__()
 
     def __setstate__(self, state):
-        pass
+        return None
 
     def __getstate__(self):
-        pass
-
+        return {}
 
 def part_arc_from_points_and_center(point_1, point_2, center):
     """_summary_

--- a/freecad/gears/connector.py
+++ b/freecad/gears/connector.py
@@ -47,21 +47,17 @@ class ViewProviderGearConnector(object):
     def getIcon(self):
         return self.icon_fn
 
-    if sys.version_info[0] == 3 and sys.version_info[1] >= 11:
+    def dumps(self):
+        return self.__getstate__()
 
-        def dumps(self):
-            return {"icon_fn": self.icon_fn}
+    def loads(self, state):
+        self.__setstate__(state)
 
-        def loads(self, state):
-            self.icon_fn = state["icon_fn"]
-    else:
+    def __getstate__(self):
+        return {"icon_fn": self.icon_fn}
 
-        def __getstate__(self):
-            return {"icon_fn": self.icon_fn}
-
-        def __setstate__(self, state):
-            self.icon_fn = state["icon_fn"]
-
+    def __setstate__(self, state) -> None:
+        self.icon_fn = state["icon_fn"]
 
 class GearConnector(object):
     def __init__(self, obj, master_gear, slave_gear):

--- a/pygears/bevel_tooth.py
+++ b/pygears/bevel_tooth.py
@@ -152,6 +152,18 @@ class BevelTooth(object):
         self.z_f = cos(self.pitch_angle - sin(pitch_angle) * 2 / self.z)
         self.add_foot = True
 
+    def dumps(self):
+        return self.__getstate__()
+
+    def loads(self, state):
+        self.__setstate__(state)
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        return None
+
     def involute_function_x(self):
         def func(s):
             return -(

--- a/pygears/cycloid_tooth.py
+++ b/pygears/cycloid_tooth.py
@@ -31,6 +31,18 @@ class CycloidTooth:
         self.head = head
         self._calc_gear_factors()
 
+    def dumps(self):
+        return self.__getstate__()
+
+    def loads(self, state):
+        self.__setstate__(state)
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        return None
+
     def _calc_gear_factors(self):
         self.d1 = self.num_teeth_1 * self.m
         self.d2 = self.num_teeth_2 * self.m

--- a/pygears/involute_tooth.py
+++ b/pygears/involute_tooth.py
@@ -65,6 +65,18 @@ class InvoluteTooth:
         self.properties_from_tool = properties_from_tool
         self._calc_gear_factors()
 
+    def dumps(self):
+        return self.__getstate__()
+
+    def loads(self, state):
+        self.__setstate__(state)
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        return None
+
     def _calc_gear_factors(self):
         if self.properties_from_tool:
             self.pressure_angle_t = arctan(tan(self.pressure_angle) / cos(self.beta))


### PR DESCRIPTION
The issue when saving gears has been fixed.

Errors associated with the following gears have been resolved: `Involute Gear`, `Internal Involute Gear`, `Involute Rack`, `Cycloid Gear`, `Cycloid Rack`, `Crown Gear`, `Worm Gear`, `Timing Gear T-shape`, `Timing Gear`, `Lantern Gear`, `Hypo Cycloid Gear`, `Bevel Gear`, and `Combine Two Gears`.

However, the error when loading `GearConnector` is still present.

For more details, see issue #146.