### PR TITLE
Apply constraint on the number of teeth of the gears

### DIFF
--- a/freecad/gears/basegear.py
+++ b/freecad/gears/basegear.py
@@ -126,11 +126,11 @@ class BaseGear:
         # Backward compatibility for old files
         if hasattr(fp, "teeth"):
             fp.addProperty(
-                "App::PropertyInteger",
+                "App::PropertyIntegerConstraint",
                 "num_teeth",
                 "base",
                 "number of teeth",
-            )
+            ).num_teeth = (15, 3, 10000, 1)
             app.Console.PrintLog(
                 app.Qt.translate(
                     "Log", "Migrating 'teeth' property to 'num_teeth' on {} part\n"

--- a/freecad/gears/bevelgear.py
+++ b/freecad/gears/bevelgear.py
@@ -39,7 +39,7 @@ class BevelGear(BaseGear):
         super(BevelGear, self).__init__(obj)
         self.bevel_tooth = BevelTooth()
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -140,7 +140,7 @@ class BevelGear(BaseGear):
 
         obj.gear = self.bevel_tooth
         obj.module = "1. mm"
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.pressure_angle = "20. deg"
         obj.pitch_angle = "45. deg"
         obj.height = "5. mm"

--- a/freecad/gears/crowngear.py
+++ b/freecad/gears/crowngear.py
@@ -38,13 +38,13 @@ class CrownGear(BaseGear):
     def __init__(self, obj):
         super(CrownGear, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
         )
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "other_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth of other gear"),
@@ -74,8 +74,8 @@ class CrownGear(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "pressure angle"),
         )
         self.add_accuracy_properties(obj)
-        obj.num_teeth = 15
-        obj.other_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
+        obj.other_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.pressure_angle = "20. deg"
         obj.height = "2. mm"

--- a/freecad/gears/cycloidgear.py
+++ b/freecad/gears/cycloidgear.py
@@ -110,23 +110,23 @@ class CycloidGear(BaseGear):
 
     def add_fillet_properties(self, obj):
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
 
     def add_tolerance_properties(self, obj):
         obj.addProperty(

--- a/freecad/gears/cycloidgear.py
+++ b/freecad/gears/cycloidgear.py
@@ -41,7 +41,7 @@ class CycloidGear(BaseGear):
         super(CycloidGear, self).__init__(obj)
         self.cycloid_tooth = CycloidTooth()
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -77,7 +77,7 @@ class CycloidGear(BaseGear):
         self.add_cycloid_properties(obj)
         self.add_computed_properties(obj)
         obj.gear = self.cycloid_tooth
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.setExpression(
             "inner_diameter", "num_teeth / 2"

--- a/freecad/gears/cycloidgearrack.py
+++ b/freecad/gears/cycloidgearrack.py
@@ -166,23 +166,23 @@ class CycloidGearRack(BaseGear):
 
     def add_fillet_properties(self, obj):
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
 
     def generate_gear_shape(self, obj):
         numpoints = obj.numpoints

--- a/freecad/gears/cycloidgearrack.py
+++ b/freecad/gears/cycloidgearrack.py
@@ -36,7 +36,7 @@ class CycloidGearRack(BaseGear):
     def __init__(self, obj):
         super(CycloidGearRack, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -81,7 +81,7 @@ class CycloidGearRack(BaseGear):
         self.add_tolerance_properties(obj)
         self.add_cycloid_properties(obj)
         self.add_fillet_properties(obj)
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.inner_diameter = 7.5
         obj.outer_diameter = 7.5

--- a/freecad/gears/internalinvolutegear.py
+++ b/freecad/gears/internalinvolutegear.py
@@ -53,7 +53,7 @@ class InternalInvoluteGear(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "simple"),
         )
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -101,7 +101,7 @@ class InternalInvoluteGear(BaseGear):
 
         obj.gear = self.involute_tooth
         obj.simple = False
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.shift = 0.0
         obj.pressure_angle = "20. deg"

--- a/freecad/gears/internalinvolutegear.py
+++ b/freecad/gears/internalinvolutegear.py
@@ -175,23 +175,23 @@ class InternalInvoluteGear(BaseGear):
 
     def add_fillet_properties(self, obj):
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
 
     def add_tolerance_properties(self, obj):
         obj.addProperty(

--- a/freecad/gears/involutegear.py
+++ b/freecad/gears/involutegear.py
@@ -59,7 +59,7 @@ class InvoluteGear(BaseGear):
         obj.gear = self.involute_tooth
         obj.simple = False
         obj.undercut = False
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.shift = 0.0
         obj.pressure_angle = "20. deg"
@@ -80,7 +80,7 @@ class InvoluteGear(BaseGear):
 
     def add_gear_properties(self, obj):
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),

--- a/freecad/gears/involutegear.py
+++ b/freecad/gears/involutegear.py
@@ -121,23 +121,23 @@ class InvoluteGear(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "undercut"),
         )
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
 
     def add_helical_properties(self, obj):
         obj.addProperty(

--- a/freecad/gears/involutegearrack.py
+++ b/freecad/gears/involutegearrack.py
@@ -162,23 +162,23 @@ class InvoluteGearRack(BaseGear):
 
     def add_fillet_properties(self, obj):
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
 
     def generate_gear_shape(self, obj):
         obj.rack.m = obj.module.Value

--- a/freecad/gears/involutegearrack.py
+++ b/freecad/gears/involutegearrack.py
@@ -34,7 +34,7 @@ class InvoluteGearRack(BaseGear):
         super(InvoluteGearRack, self).__init__(obj)
         self.involute_rack = InvoluteRack()
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -79,7 +79,7 @@ class InvoluteGearRack(BaseGear):
         self.add_involute_properties(obj)
         self.add_fillet_properties(obj)
         obj.rack = self.involute_rack
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.pressure_angle = "20. deg"
         obj.height = "5. mm"

--- a/freecad/gears/lanterngear.py
+++ b/freecad/gears/lanterngear.py
@@ -34,7 +34,7 @@ class LanternGear(BaseGear):
     def __init__(self, obj):
         super(LanternGear, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "gear_parameter",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -72,7 +72,7 @@ class LanternGear(BaseGear):
             ),
         )
 
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.bolt_radius = "1 mm"
 

--- a/freecad/gears/timinggear.py
+++ b/freecad/gears/timinggear.py
@@ -106,7 +106,7 @@ class TimingGear(BaseGear):
     def __init__(self, obj):
         super(TimingGear, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -175,7 +175,7 @@ class TimingGear(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "x-offset of second arc-midpoint"),
             1,
         )
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.type = ["gt2", "gt3", "gt5", "gt8", "htd3", "htd5", "htd8"]
         obj.height = "5. mm"
 

--- a/freecad/gears/timinggear_t.py
+++ b/freecad/gears/timinggear_t.py
@@ -69,23 +69,23 @@ class TimingGearT(BaseGear):
             ),
         )
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "head_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-head, radius = head_fillet x module",
             ),
-        )
+        ).head_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
-            "App::PropertyFloat",
+            "App::PropertyFloatConstraint",
             "root_fillet",
             "fillets",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "a fillet for the tooth-root, radius = root_fillet x module",
             ),
-        )
+        ).root_fillet = (0.0, 0.0, 1000.0, 0.01)
         obj.addProperty(
             "App::PropertyAngle",
             "alpha",

--- a/freecad/gears/timinggear_t.py
+++ b/freecad/gears/timinggear_t.py
@@ -40,7 +40,7 @@ class TimingGearT(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "pitch of gear"),
         )
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -99,7 +99,7 @@ class TimingGearT(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "extrusion height"),
         )
         obj.pitch = "5. mm"
-        obj.num_teeth = 15
+        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
         obj.tooth_height = "1.2 mm"
         obj.u = "0.6 mm"
         obj.alpha = "40. deg"

--- a/freecad/gears/wormgear.py
+++ b/freecad/gears/wormgear.py
@@ -35,7 +35,7 @@ class WormGear(BaseGear):
     def __init__(self, obj):
         super(WormGear, self).__init__(obj)
         obj.addProperty(
-            "App::PropertyInteger",
+            "App::PropertyIntegerConstraint",
             "num_teeth",
             "base",
             QT_TRANSLATE_NOOP("App::Property", "number of teeth"),
@@ -93,7 +93,7 @@ class WormGear(BaseGear):
                 "App::Property", "clearance * module = additional length of root"
             ),
         )
-        obj.num_teeth = 3
+        obj.num_teeth = (3, 2, 100, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.pressure_angle = "20. deg"
         obj.height = "5. mm"


### PR DESCRIPTION
- Use `App::PropertyIntegerConstraint` instead of `App::PropertyInteger` in order to get a smaller set of valid options for the parts.

Minimum, maximum, step and default values are set.

Previously you could enter negative numbers which were fixed at the time of generating the shape avoiding problems but the properties were not fixed. Now users are not able to enter bad data which leads to a simplification of the sanitization code.

Proposed upper limit at 10,000. Users are crazy.

**Are there missing properties that also should be changed?** I think all remaining `Float` properties should have a 0 limit, is the same limit I used on the fillets ok?

---

I made similar change on FreeGrid WB and there was no problem with old files. [commit](https://github.com/instancezero/in3dca-freegrid/commit/3a8433711427547a2775b6d17df713f0a8cf290e#diff-d5d2230f682b7fa3ab9cfbb176f48935d905da980777d7a6e273321fdfffc63bR50)