### PR TITLE
Fix typos

### DIFF
--- a/freecad/gears/bevelgear.py
+++ b/freecad/gears/bevelgear.py
@@ -95,7 +95,7 @@ class BevelGear(BaseGear):
             "tolerance",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The arc length on the pitch circle by which the tooth thicknes is reduced.",
+                "The arc length on the pitch circle by which the tooth thickness is reduced.",
             ),
         )
         obj.addProperty(

--- a/freecad/gears/cycloidgear.py
+++ b/freecad/gears/cycloidgear.py
@@ -172,7 +172,7 @@ class CycloidGear(BaseGear):
             "tolerance",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The arc length on the pitch circle by which the tooth thicknes is reduced.",
+                "The arc length on the pitch circle by which the tooth thickness is reduced.",
             ),
         )
         obj.addProperty(

--- a/freecad/gears/internalinvolutegear.py
+++ b/freecad/gears/internalinvolutegear.py
@@ -258,7 +258,7 @@ class InternalInvoluteGear(BaseGear):
             "tolerance",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The arc length on the pitch circle by which the tooth thicknes is reduced.",
+                "The arc length on the pitch circle by which the tooth thickness is reduced.",
             ),
         )
         obj.addProperty(

--- a/freecad/gears/involutegear.py
+++ b/freecad/gears/involutegear.py
@@ -312,7 +312,7 @@ class InvoluteGear(BaseGear):
             "tolerance",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The arc length on the pitch circle by which the tooth thicknes is reduced.",
+                "The arc length on the pitch circle by which the tooth thickness is reduced.",
             ),
         )
         obj.addProperty(

--- a/freecad/gears/involutegearrack.py
+++ b/freecad/gears/involutegearrack.py
@@ -123,7 +123,7 @@ class InvoluteGearRack(BaseGear):
             "App::PropertyAngle",
             "helix_angle",
             "helical",
-            QT_TRANSLATE_NOOP("App::Property", "helix anglle"),
+            QT_TRANSLATE_NOOP("App::Property", "helix angle"),
         )
         obj.addProperty(
             "App::PropertyBool",

--- a/freecad/gears/timinggear_t.py
+++ b/freecad/gears/timinggear_t.py
@@ -65,7 +65,7 @@ class TimingGearT(BaseGear):
             "tolerance",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The arc length on the pitch circle by which the tooth thicknes is reduced.",
+                "The arc length on the pitch circle by which the tooth thickness is reduced.",
             ),
         )
         obj.addProperty(


### PR DESCRIPTION
"anggle" -> "angle", spotten on CrowdIn, with help of Kay G
"thicknes" -> "thickness", found with `awk 'BEGIN { RS="</source>" } /<source>/ { sub(/.*<source>/, ""); print }' Gear.ts | aspell --lang=en list | sort | uniq
`

Should "topologic" from "if enabled the rack is drawn with a constant number of teeth to avoid topologic renaming." be "topological"? _Marked as typo by aspell_