### PR TITLE
Lower the minimum number of teeth for a cycloid gear

### DIFF
--- a/freecad/gears/cycloidgear.py
+++ b/freecad/gears/cycloidgear.py
@@ -77,7 +77,7 @@ class CycloidGear(BaseGear):
         self.add_cycloid_properties(obj)
         self.add_computed_properties(obj)
         obj.gear = self.cycloid_tooth
-        obj.num_teeth = (15, 3, 10000, 1)  # default, min, max, step
+        obj.num_teeth = (15, 2, 10000, 1)  # default, min, max, step
         obj.module = "1. mm"
         obj.setExpression(
             "inner_diameter", "num_teeth / 2"


### PR DESCRIPTION
When using full hypocycloid/epicycloid as tooth, we can go as low as two lobes, but the previous minimum of 3 prevents this. Actually, with
```
   inner_diameter: 0.5
   outer_diameter: = inner_diameter
   clearance: = -1 + inner_diameter - 1e-06
   head: = -1 + outer_diameter - 1e-06
```
we could go as low as one, but I doubt there are practical applications for that.

Use case: https://commons.wikimedia.org/wiki/File:Roots_blower_-_2_lobes.svg