### PR TITLE
Fix crash on file open: don't recompute the document from onChanged()

### DIFF
--- a/freecad/gears/chainconnector.py
+++ b/freecad/gears/chainconnector.py
@@ -58,59 +58,20 @@ class ChainConnector(object):
         obj.addProperty("App::PropertyLink", "input_connector", "GearChain",
                         QT_TRANSLATE_NOOP("App::Property", "Previous connector in the chain"), 1)
         obj.addProperty("App::PropertyLink", "master_gear", "GearChain",
-                        QT_TRANSLATE_NOOP("App::Property", "The shared master gear (G2)"), 8) # Read-only link to G2
+                        QT_TRANSLATE_NOOP("App::Property", "The shared master gear (G2)"), 8)
         obj.addProperty("App::PropertyLink", "slave_gear", "GearChain",
                         QT_TRANSLATE_NOOP("App::Property", "The new slave gear (G3)"), 1)
         obj.addProperty("App::PropertyAngle", "input_gear_angle", "GearChain",
                         QT_TRANSLATE_NOOP("App::Property", "Calculated rotation angle of the shared gear (G2)"), 8)
         
-        # FIX 2: Add version property assignment
         obj.version = __version__
         obj.input_connector = master_connector
         obj.slave_gear = slave_gear
         obj.Proxy = self
         
-        # CRITICAL FIX: Attach the ViewProvider to ensure visibility
         ViewProviderGearConnector(obj.ViewObject)
 
-        # 1. Link master_gear (G2) property to the slave_gear of the previous connector (GC1.slave_gear)
         obj.setExpression('master_gear', f'{master_connector.Name}.slave_gear')
-
-        # 2. Link the input_gear_angle to G2's rotation. This triggers onChanged whenever G2 moves.
-        #    We convert radians (from .Angle) to degrees for consistency, though
-        #    onChanged will convert it back. Or we can just use the raw Angle.
-        obj.setExpression('input_gear_angle', f'{master_connector.Name}.slave_gear.Placement.Rotation.Angle')
-        self.onChanged(obj, 'input_gear_angle')
-
-    def __init__(self, obj, master_connector, slave_gear):
-        
-        # --- PROPERTY DEFINITIONS ---
-        obj.addProperty("App::PropertyString", "version", "version",
-                        QT_TRANSLATE_NOOP("App::Property", "freecad.gears-version"), 1)
-        obj.addProperty("App::PropertyLink", "input_connector", "GearChain",
-                        QT_TRANSLATE_NOOP("App::Property", "Previous connector in the chain"), 1)
-        obj.addProperty("App::PropertyLink", "master_gear", "GearChain",
-                        QT_TRANSLATE_NOOP("App::Property", "The shared master gear (G2)"), 8) # Read-only link to G2
-        obj.addProperty("App::PropertyLink", "slave_gear", "GearChain",
-                        QT_TRANSLATE_NOOP("App::Property", "The new slave gear (G3)"), 1)
-        obj.addProperty("App::PropertyAngle", "input_gear_angle", "GearChain",
-                        QT_TRANSLATE_NOOP("App::Property", "Calculated rotation angle of the shared gear (G2)"), 8)
-        
-        # FIX 2: Add version property assignment
-        obj.version = __version__
-        obj.input_connector = master_connector
-        obj.slave_gear = slave_gear
-        obj.Proxy = self
-        
-        # CRITICAL FIX: Attach the ViewProvider to ensure visibility
-        ViewProviderGearConnector(obj.ViewObject)
-
-        # 1. Link master_gear (G2) property to the slave_gear of the previous connector (GC1.slave_gear)
-        obj.setExpression('master_gear', f'{master_connector.Name}.slave_gear')
-
-        # 2. Link the input_gear_angle to G2's rotation. This triggers onChanged whenever G2 moves.
-        #    We convert radians (from .Angle) to degrees for consistency, though
-        #    onChanged will convert it back. Or we can just use the raw Angle.
         obj.setExpression('input_gear_angle', f'{master_connector.Name}.slave_gear.Placement.Rotation.Angle')
 
 

--- a/freecad/gears/commands.py
+++ b/freecad/gears/commands.py
@@ -210,6 +210,14 @@ class CreateGearConnector(BaseCommand):
     MenuText = QT_TRANSLATE_NOOP("FCGear_GearConnector", "Combine two gears")
     ToolTip = QT_TRANSLATE_NOOP("FCGear_GearConnector", "Combine two gears")
 
+    @staticmethod
+    def _find_body(obj):
+        """Return the PartDesign::Body containing obj, or None."""
+        for parent in obj.InList:
+            if hasattr(parent, "TypeId") and parent.TypeId == "PartDesign::Body":
+                return parent
+        return None
+
     def Activated(self):
         try:
             selection = gui.Selection.getSelection()
@@ -257,6 +265,21 @@ class CreateGearConnector(BaseCommand):
                 obj = app.ActiveDocument.addObject("Part::FeaturePython", self.NAME)
                 GearConnector(obj, selection[0], selection[1])
                 ViewProviderGearConnector(obj.ViewObject)
+
+                # If the gears live inside a PartDesign Body, the connector must
+                # be added to the same body. Cross-scope PropertyLinks are not
+                # allowed and will cause a SIGSEGV on document restore.
+                body0 = self._find_body(selection[0])
+                body1 = self._find_body(selection[1])
+                if body0 != body1 and (body0 is not None or body1 is not None):
+                    app.Console.PrintWarning(
+                        "FCGear GearConnector: The selected gears are in different "
+                        "scopes. Cross-scope links are not supported and may cause "
+                        "issues. Place both gears in the same body or outside any body.\n"
+                    )
+                body = body0 or body1
+                if body:
+                    body.addObject(obj)
 
             app.ActiveDocument.recompute()
             return obj

--- a/freecad/gears/connector.py
+++ b/freecad/gears/connector.py
@@ -64,8 +64,6 @@ class ViewProviderGearConnector(object):
 
 
 class GearConnector(object):
-    _recomputing = False
-
     def __init__(self, obj, master_gear, slave_gear):
         obj.addProperty(
             "App::PropertyString",
@@ -130,19 +128,20 @@ class GearConnector(object):
 
 
     def onChanged(self, fp, prop):
-        if self._recomputing:
-            return
-        # Guard: Check if gears are initialized
         if not hasattr(fp, 'master_gear') or not hasattr(fp, 'slave_gear'):
             return
         if fp.master_gear is None or fp.slave_gear is None:
             return
 
-        # FIX 3: This connector is *always* driven by its angle1 property.
-        # Removing the 'if prop == angle1' check ensures it runs on
-        # manual changes (prop='angle1') AND on document recompute (prop=None).
-        # This provides a stable position for G2, which fixes the chain.
-        master_angle = fp.angle1.Value # Angle in degrees
+        # Only recompute positions on user-driven property changes.
+        # Skipping link properties ('master_gear', 'slave_gear') avoids calling
+        # app.ActiveDocument.recompute() during document restore, which would
+        # attempt to recompute partially-loaded objects and cause a SIGSEGV in
+        # App::LocalCoordinateSystem::getAxis().
+        if prop not in ('angle1', 'master_gear_stationary', 'slave_gear_stationary'):
+            return
+
+        master_angle = fp.angle1.Value
             
         # ====================================================================
         # INVOLUTE GEAR TO INVOLUTE GEAR
@@ -380,12 +379,7 @@ class GearConnector(object):
                 mat1.move(fp.slave_gear.Placement.Base)
                 fp.master_gear.Placement = mat1
                 fp.master_gear.purgeTouched()
-        self._recomputing = True
-        app.ActiveDocument.recompute()
-        self._recomputing = False
 
     def execute(self, fp):
-        # We pass 'angle1' here to ensure the logic runs,
-        # as the 'prop' check was removed.
         self.onChanged(fp, 'angle1')
 


### PR DESCRIPTION
Related to: https://github.com/looooo/freecad.gears/issues/228

Can be reproduced with attached model:
[drug-safe.zip](https://github.com/user-attachments/files/30154834/drug-safe.zip)


Unfortunately patch was created by big part with help of AI, only thing I found out is that order of recomputations was causing issues. And when I disabled recomputation on load it fixed stuff.

I've been using this fix for more than a month and it seems to be stable.

    Opening a file that contains a GearConnector could kill FreeCAD with a
    segmentation fault before the document even finished loading.
    
    Why it crashed
    --------------
    While FreeCAD loads a document it restores properties one by one, and
    restoring a property fires the same onChanged() callback as a user edit.
    GearConnector.onChanged() reacted to every change by calling
    app.ActiveDocument.recompute() -- so the whole document got recomputed
    in the middle of loading, while most objects were only half restored.
    
    One of those half-restored objects is the document's origin
    (App::LocalCoordinateSystem, introduced in FreeCAD 1.1): the object
    itself already exists, but its axis children are not loaded yet.
    Recomputing it at that moment makes getAxis() dereference a null
    pointer, and FreeCAD dies with SIGSEGV.
    
    The crash was easiest to trigger with gears living inside a PartDesign
    Body: the connector's links then point out of its allowed scope, which
    FreeCAD warns about right before the crash.
    
    What changed
    ------------
    * connector.py: onChanged() no longer calls recompute(), and the
      _recomputing guard flag is gone. Calling a document recompute from
      inside onChanged() is never safe -- FreeCAD fires onChanged() during
      file loading, expression evaluation and other internal operations.
      The dependency graph already propagates changes when execute() runs
      during a normal recompute. onChanged() now also only reacts to the
      user-facing properties (angle1, master/slave_gear_stationary), so
      restoring link properties can't retrigger the position math.
    
    * commands.py: when the selected gears live inside a PartDesign Body,
      create the connector inside that same Body (new _find_body() helper)
      instead of at document level. This avoids the out-of-scope links that
      produced the warning and made the crash easy to hit.
    
    * chainconnector.py: remove a duplicate ChainConnector.__init__ that
      silently shadowed the first definition.
