### PR TITLE
fix timinggear shape calculation with offset=0.0 and update htd5 data

### DIFF
--- a/freecad/gears/timinggear.py
+++ b/freecad/gears/timinggear.py
@@ -84,11 +84,11 @@ class TimingGear(BaseGear):
         "htd5": {
             "pitch": 5.0,
             "u": 0.5715,
-            "h": 2.06,
+            "h": 2.16,  # real pulley valley depth, not the specified belt teeth height (2.06)
             "H": 3.80,
-            "r0": 1.49,
-            "r1": 1.49,
-            "rs": 0.43,
+            "r0": 1.6,  # pulley from SolidEdge measured, 1.56 would be probably enough
+            "r1": 1.6,  # unused with offset = 0.0
+            "rs": 0.48,  # SolidEdge pulley: rs = 0.45, manufacturer data (0.48/0.50)
             "offset": 0.0,
         },
         "htd8": {
@@ -202,10 +202,34 @@ class TimingGear(BaseGear):
             phi5 = np.pi / fp.num_teeth
             ref = reflection(-phi5 - np.pi / 2.0)
             rp = pitch * fp.num_teeth / np.pi / 2.0 - u
+            root_y = rp - h
 
-            m_34 = np.array([-(r_12 + r_34), rp - h + r_12])
-            x2 = np.array([-r_12, m_34[1]])
-            x4 = np.array([m_34[0], m_34[1] + r_34])
+            # center of the root/valley arc (radius r_12): sits on the
+            # y-axis, r_12 above the deepest point of the valley (0, root_y)
+            c0 = np.array([0.0, root_y + r_12])
+
+            # m_34 (center of the fillet arc, radius r_34) must satisfy two
+            # tangency conditions simultaneously:
+            #   - tangent to the root arc:   |m_34 - c0| = r_12 + r_34
+            #   - tangent to the tip circle: |m_34 - 0| = rp - r_34
+            # this is the intersection of two circles, solved the same way
+            # phi4 is solved for in the offset != 0 branch below.
+            R1 = r_12 + r_34
+            R2 = rp - r_34
+            d = np.linalg.norm(c0)
+            a = (d**2 + R1**2 - R2**2) / (2 * d)  # distance from c0 towards origin
+            b = np.sqrt(max(R1**2 - a**2, 0.0))
+            to_origin = -c0 / d
+            perp = np.array([-to_origin[1], to_origin[0]])
+            m_34 = c0 + a * to_origin - b * perp
+
+            # exact tangent point between the root arc and the fillet,
+            # replaces the old fixed assumption x2 = [-r_12, c0[1]]
+            x2 = c0 + r_12 * (m_34 - c0) / np.linalg.norm(m_34 - c0)
+            # exact tangent point on the tip circle (radius rp), replaces
+            # the old approximation "m_34 + [0, r_34]" which did not
+            # actually lie on that circle
+            x4 = rp * m_34 / np.linalg.norm(m_34)
             x6 = ref(x4)
 
             mir = np.array([-1.0, 1.0])
@@ -217,7 +241,7 @@ class TimingGear(BaseGear):
             arcs.append(
                 part.Arc(
                     app.Vector(*xn2, 0.0),
-                    app.Vector(0, rp - h, 0.0),
+                    app.Vector(0, root_y, 0.0),
                     app.Vector(*x2, 0.0),
                 ).toShape()
             )


### PR DESCRIPTION
Fixes #237

## Summary

Two related fixes to `freecad/gears/timinggear.py`, in the `offset == 0.0` construction branch used by `htd3`/`htd5`/`htd8`:

**1) Tangency bug fix (bugfix):** `m_34`/`x2`/`x4` were computed via a hardcoded approximation that doesn't actually satisfy tangency between the fillet arc and the tooth-tip arc. As a result the constructed tooth never reached the specified `h` (tooth height) — for large tooth counts the shortfall converges to exactly `u - rs`. Fixed by solving `m_34` as the intersection of two tangency circles, the same approach already used for `phi4` in the `offset != 0` branch just below. After the fix, tooth height matches `h` exactly for any tooth count (verified for N=8 to N=100000).

**2) Updated `htd5` profile constants (r0/r1/rs/h):** the previous values (1.49/1.49/0.43/2.06) produce zero clearance between a genuine Gates HTD5M belt tooth and the printed pulley groove. Updated based on a measured known-good commercial pulley plus two independent manufacturer-style reference drawings — see #237 for the full derivation and source comparison. This part is lower-confidence than (1); happy to adjust if someone has access to an authoritative Gates/SDP-SI manufacturing drawing.

Printed and tested physically against a real Gates PowerGrip HTD 5M belt (140-tooth pulley); belt now seats correctly.
