### PR TITLE
Make number of points used for bevel helix curve configurable

### DIFF
--- a/freecad/gears/bevelgear.py
+++ b/freecad/gears/bevelgear.py
@@ -81,6 +81,12 @@ class BevelGear(BaseGear):
             QT_TRANSLATE_NOOP("App::Property", "number of points for spline"),
         )
         obj.addProperty(
+            "App::PropertyInteger",
+            "numpoints_helix",
+            "precision",
+            QT_TRANSLATE_NOOP("App::Property", "number of points for helix curve"),
+        )
+        obj.addProperty(
             "App::PropertyBool",
             "reset_origin",
             "base",
@@ -155,6 +161,7 @@ class BevelGear(BaseGear):
         obj.pitch_angle = "45. deg"
         obj.height = "5. mm"
         obj.numpoints = 20
+        obj.numpoints_helix = 20
         obj.backlash = "0.00 mm"
         obj.clearance = 0.1
         obj.beta = "0 deg"
@@ -203,7 +210,7 @@ class BevelGear(BaseGear):
             wires.append(make_bspline_wire([scale_0 * p for p in pts]))
             wires.append(make_bspline_wire([scale_1 * p for p in pts]))
         else:
-            for scale_i in np.linspace(scale_0, scale_1, 20):
+            for scale_i in np.linspace(scale_0, scale_1, fp.numpoints_helix):
                 # beta_i = (scale_i - scale_0) * fp.beta.Value * np.pi / 180
                 # rot = rotation3D(- beta_i)
                 # points = [rot(pt) * scale_i for pt in pts]


### PR DESCRIPTION
Adds `numpoints_helix` parameter to BevelGear, which controls a value that was previously hardcoded to `20`

This allows the precision of the helix curves in bevel to be controlled.

I've just copied the naming from `numpoints` which controls the resolution of gear teeth themselves. Not sure if it would be better to name it something like `numwires_helix` as it's not changing the number of points, but the number of wires/bsplines that are lofted across.

It defaults to 20, so nothing should change from how it was before, unless the new parameter is changed intentionally.

I've tested it and it seems to work fine, though using small enough values can (expectedly) result in weird curves.

@looooo I wonder if it is possible to use only use a single, intermediate, half-rotated profile, instead of subdividing a ton along the rotation axis, that way we would always loft across only 3 profiles.